### PR TITLE
Tell pytest to use a junit report family compatible with Jenkins

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
This corrects the issue of jobs receiving a `SUCCESS` status when tests are actually failing.
The job status with failing tests is defined to be `UNSTABLE` (yellow/orange).